### PR TITLE
Add possibility to provide existing keys in setup commands

### DIFF
--- a/app/generate_tagging_secrets.go
+++ b/app/generate_tagging_secrets.go
@@ -3,17 +3,22 @@ package main
 import (
 	"errors"
 	"github.com/lca1/medco-unlynx/services"
+	libunlynx "github.com/lca1/unlynx/lib"
+	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3/app"
 	"go.dedis.ch/onet/v3/log"
 	"gopkg.in/urfave/cli.v1"
 	"os"
 	"path"
 	"strconv"
+	"strings"
 )
 
 func generateTaggingSecrets(c *cli.Context) error {
 	// cli arguments
 	groupTomlPath := c.String("file")
+	providedSecretsString := c.String("secrets")
+	nodeIndex := c.Int("nodeIndex")
 
 	if groupTomlPath == "" {
 		err := errors.New("arguments not OK")
@@ -38,14 +43,47 @@ func generateTaggingSecrets(c *cli.Context) error {
 		return err
 	}
 
-	for i := range el.Roster.List {
-		dir, _ := path.Split(groupTomlPath)
+	// parse provided secrets
+	var providedSecrets []kyber.Scalar
+	if providedSecretsString != "" {
 
-		for _, dest := range el.Roster.List {
-			_, err := servicesmedco.CheckDDTSecrets(dir+"srv"+strconv.FormatInt(int64(i), 10)+"-ddtsecrets.toml", dest.Address)
+		providedSecretsStringSplit := strings.Split(providedSecretsString, ",")
+		if len(providedSecretsStringSplit) != len(el.Roster.List) {
+			err := errors.New("provided secrets list does not match the length of the roster list")
+			log.Error(err, len(providedSecretsStringSplit), " != ", len(el.Roster.List))
+			return err
+		}
+
+		for _, s := range providedSecretsStringSplit {
+			providedSecretScalar, err := libunlynx.DeserializeScalar(s)
 			if err != nil {
+				log.Error(err)
 				return err
 			}
+
+			providedSecrets = append(providedSecrets, providedSecretScalar)
+		}
+	}
+
+	// setup secrets
+	dir, _ := path.Split(groupTomlPath)
+
+	for i, dest := range el.Roster.List {
+		var err error
+		if len(providedSecrets) > 0 {
+			_, err = servicesmedco.CheckDDTSecrets(
+				dir+"srv"+strconv.FormatInt(int64(nodeIndex), 10)+"-ddtsecrets.toml",
+				dest.Address,
+				providedSecrets[i])
+		} else {
+			_, err = servicesmedco.CheckDDTSecrets(
+				dir+"srv"+strconv.FormatInt(int64(nodeIndex), 10)+"-ddtsecrets.toml",
+				dest.Address,
+				nil)
+		}
+
+		if err != nil {
+			return err
 		}
 	}
 

--- a/app/medco.go
+++ b/app/medco.go
@@ -42,6 +42,16 @@ const (
 
 	optionPublicTomlPath      = "publicTomlPath"
 	optionPublicTomlPathShort = "pub"
+
+	optionProvidedPubKey      = "pubKey"
+
+	optionProvidedPrivKey     = "privKey"
+
+	optionProvidedSecrets      = "secrets"
+	optionProvidedSecretsShort = "s"
+
+	optionNodeIndex      = "nodeIndex"
+	optionNodeIndexShort = "i"
 )
 
 /*
@@ -106,6 +116,14 @@ func main() {
 			Name:  optionPublicTomlPath + ", " + optionPublicTomlPathShort,
 			Usage: "Public toml file path",
 		},
+		cli.StringFlag{
+			Name:  optionProvidedPubKey,
+			Usage: "Provided public key (optional)",
+		},
+		cli.StringFlag{
+			Name:  optionProvidedPrivKey,
+			Usage: "Provided private key (optional)",
+		},
 	}
 
 	getAggregateKeyFlags := []cli.Flag{
@@ -113,6 +131,14 @@ func main() {
 			Name:  optionGroupFile + ", " + optionGroupFileShort,
 			Value: DefaultGroupFile,
 			Usage: "Unlynx group definition file",
+		},
+		cli.StringFlag{
+			Name:  optionProvidedSecrets + ", " + optionProvidedSecretsShort,
+			Usage: "Provided secrets (optional). Repeat the option to put several.",
+		},
+		cli.IntFlag{
+			Name:  optionNodeIndex + ", " + optionNodeIndexShort,
+			Usage: "Node index of the server for which the secrets are generated",
 		},
 	}
 

--- a/app/medco.go
+++ b/app/medco.go
@@ -43,9 +43,9 @@ const (
 	optionPublicTomlPath      = "publicTomlPath"
 	optionPublicTomlPathShort = "pub"
 
-	optionProvidedPubKey      = "pubKey"
+	optionProvidedPubKey = "pubKey"
 
-	optionProvidedPrivKey     = "privKey"
+	optionProvidedPrivKey = "privKey"
 
 	optionProvidedSecrets      = "secrets"
 	optionProvidedSecretsShort = "s"

--- a/app/non_interactive_setup.go
+++ b/app/non_interactive_setup.go
@@ -20,24 +20,36 @@ func NonInteractiveSetup(c *cli.Context) error {
 	privateTomlPath := c.String("privateTomlPath")
 	publicTomlPath := c.String("publicTomlPath")
 
+	// provided keys (optional)
+	providedPubKey := c.String("pubKey")
+	providedPrivKey := c.String("privKey")
+
 	if serverBindingStr == "" || description == "" || privateTomlPath == "" || publicTomlPath == "" {
 		err := errors.New("arguments not OK")
 		log.Error(err)
 		return cli.NewExitError(err, 3)
 	}
 
-	kp := key.NewKeyPair(libunlynx.SuiTe)
+	var privStr, pubStr string
+	var err error
+	if providedPubKey != "" {
+		privStr = providedPrivKey
+		pubStr = providedPubKey
+	} else {
+		kp := key.NewKeyPair(libunlynx.SuiTe)
 
-	privStr, err := encoding.ScalarToStringHex(libunlynx.SuiTe, kp.Private)
-	if err != nil {
-		log.Error("failed to convert scalar to hexadecimal")
-		return cli.NewExitError(err, 3)
+		privStr, err = encoding.ScalarToStringHex(libunlynx.SuiTe, kp.Private)
+		if err != nil {
+			log.Error("failed to convert scalar to hexadecimal")
+			return cli.NewExitError(err, 3)
+		}
+		pubStr, err = encoding.PointToStringHex(libunlynx.SuiTe, kp.Public)
+		if err != nil {
+			log.Error("failed to convert point to hexadecimal")
+			return cli.NewExitError(err, 3)
+		}
 	}
-	pubStr, err := encoding.PointToStringHex(libunlynx.SuiTe, kp.Public)
-	if err != nil {
-		log.Error("failed to convert point to hexadecimal")
-		return cli.NewExitError(err, 3)
-	}
+
 	public, err := encoding.StringHexToPoint(libunlynx.SuiTe, pubStr)
 	if err != nil {
 		log.Error("failed to convert hexadecimal to point")

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -235,14 +235,14 @@ func TestServiceShuffle(t *testing.T) {
 
 func TestCheckDDTSecrets(t *testing.T) {
 	addr := network.NewLocalAddress("local://127.0.0.1:2020")
-	_, err := servicesmedco.CheckDDTSecrets("secrets.toml", addr)
+	_, err := servicesmedco.CheckDDTSecrets("secrets.toml", addr, nil)
 	assert.Nil(t, err, "Error while writing the secrets to the TOML file")
 
 	addr = network.NewLocalAddress("local://127.0.0.1:2010")
-	_, err = servicesmedco.CheckDDTSecrets("secrets.toml", addr)
+	_, err = servicesmedco.CheckDDTSecrets("secrets.toml", addr, nil)
 	assert.Nil(t, err, "Error while writing the secrets to the TOML file")
 
 	addr = network.NewLocalAddress("local://127.0.0.1:2000")
-	_, err = servicesmedco.CheckDDTSecrets("secrets.toml", addr)
+	_, err = servicesmedco.CheckDDTSecrets("secrets.toml", addr, nil)
 	assert.Nil(t, err, "Error while writing the secrets to the TOML file")
 }


### PR DESCRIPTION
In functions NonInteractiveSetup and generateTaggingSecrets.

Additionally fix problem where secrets for all nodes were generated in generateTaggingSecrets. 
Now generate only for a specified node.