### PR TITLE
base64.URLEncoding

### DIFF
--- a/app/get_aggregate_key.go
+++ b/app/get_aggregate_key.go
@@ -47,7 +47,7 @@ func getAggregateKey(c *cli.Context) error {
 	}
 	defer fWrite.Close()
 
-	_, err = fWrite.WriteString(base64.StdEncoding.EncodeToString(b))
+	_, err = fWrite.WriteString(base64.URLEncoding.EncodeToString(b))
 	if err != nil {
 		return err
 	}

--- a/services/service.go
+++ b/services/service.go
@@ -944,7 +944,7 @@ func createTOMLSecrets(path string, id network.Address) (kyber.Scalar, error) {
 	}
 
 	aux := make([]secretDDT, 0)
-	aux = append(aux, secretDDT{ServerID: id.String(), Secret: base64.StdEncoding.EncodeToString(b)})
+	aux = append(aux, secretDDT{ServerID: id.String(), Secret: base64.URLEncoding.EncodeToString(b)})
 	endR := privateTOML{Public: "", Private: "", Address: "", Description: "", Secrets: aux}
 
 	err = encoder.Encode(&endR)
@@ -991,7 +991,7 @@ func CheckDDTSecrets(path string, id network.Address) (kyber.Scalar, error) {
 		if el.ServerID == id.String() {
 			secret := libunlynx.SuiTe.Scalar()
 
-			b, err := base64.StdEncoding.DecodeString(el.Secret)
+			b, err := base64.URLEncoding.DecodeString(el.Secret)
 			if err != nil {
 				log.Error(err)
 				return nil, err
@@ -1016,7 +1016,7 @@ func CheckDDTSecrets(path string, id network.Address) (kyber.Scalar, error) {
 		return nil, err
 	}
 
-	contents.Secrets = append(contents.Secrets, secretDDT{ServerID: id.String(), Secret: base64.StdEncoding.EncodeToString(b)})
+	contents.Secrets = append(contents.Secrets, secretDDT{ServerID: id.String(), Secret: base64.URLEncoding.EncodeToString(b)})
 
 	err = addTOMLSecret(path, contents)
 	if err != nil {


### PR DESCRIPTION
Switched all references of base64.StdEncoding by base64.URLEncoding. Unlynx and medco-loader are all using base64.URLEncoding too.